### PR TITLE
Fix memory in MP4Modify

### DIFF
--- a/src/mp4file.cpp
+++ b/src/mp4file.cpp
@@ -190,6 +190,9 @@ bool MP4File::Modify( const char* fileName )
             // get rid of any trailing free or skips
             if (!strcmp(type, "free") || !strcmp(type, "skip")) {
                 m_pRootAtom->DeleteChildAtom(pAtom);
+                // Deallocate the atom after removing.
+                delete pAtom;
+                
                 continue;
             }
 


### PR DESCRIPTION
Fix memory leak caused by calling MP4Modify(). This is caused by a "free" atom
getting removed without de-allocating.