### PR TITLE
fixes compile problem

### DIFF
--- a/src/rtphint.cpp
+++ b/src/rtphint.cpp
@@ -339,7 +339,7 @@ void MP4RtpHintTrack::GetPayload(
                 pSlash = strchr(pSlash, '/');
                 if (pSlash != NULL) {
                     pSlash++;
-                    if (pSlash != '\0') {
+                    if (*pSlash != '\0') {
                         length = (uint32_t)strlen(pRtpMap) - (pSlash - pRtpMap);
                         *ppEncodingParams = (char *)MP4Calloc(length + 1);
                         strncpy(*ppEncodingParams, pSlash, length);


### PR DESCRIPTION
fix: #11 

two lines above this one, you already checked if pSlash is NULL.  I feel pretty certain you're checking that you haven't gone past the string's end with this test, which means you intend to check the value of the byte at pSlash rather than the pointer.  This does address the compiler's complaint with this code.